### PR TITLE
Make the docs on MigrationValidation more precise

### DIFF
--- a/src/Database/PostgreSQL/Simple/Migration.hs
+++ b/src/Database/PostgreSQL/Simple/Migration.hs
@@ -250,7 +250,7 @@ data MigrationCommand
     | MigrationScript ScriptName BS.ByteString
     -- ^ Executes a migration based on the provided bytestring.
     | MigrationValidation MigrationCommand
-    -- ^ Validates the provided MigrationCommand.
+    -- ^ Validates that the provided MigrationCommand has been executed.
     | MigrationCommands [MigrationCommand]
     -- ^ Performs a series of 'MigrationCommand's in sequence.
     deriving (Show, Eq, Read, Ord)


### PR DESCRIPTION
I was slightly confused at first because I thought I can put commands
into `MigrationValidation` that validate my schema, e.g., by checking that
tables are present. This PR makes it more clear that
`MigrationValidation` only checks that the command has been executed.