### PR TITLE
Help locate errors

### DIFF
--- a/postgresql-simple-migration.cabal
+++ b/postgresql-simple-migration.cabal
@@ -33,6 +33,7 @@ source-repository head
 Library
     exposed-modules:        Database.PostgreSQL.Simple.Migration
                             Database.PostgreSQL.Simple.Util
+                            Database.PostgreSQL.Simple.Parser
     hs-source-dirs:         src
     ghc-options:            -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns
     default-extensions:     OverloadedStrings, CPP, LambdaCase
@@ -71,4 +72,5 @@ test-suite tests
                             bytestring                  >= 0.10     && < 0.11,
                             postgresql-simple           >= 0.4      && < 0.6,
                             hspec                       >= 2.2      && < 2.5,
-                            postgresql-simple-migration
+                            postgresql-simple-migration,
+                            string-qq                   >= 0.0.2    && < 0.0.3

--- a/src/Database/PostgreSQL/Simple/Migration.hs
+++ b/src/Database/PostgreSQL/Simple/Migration.hs
@@ -11,12 +11,13 @@
 --
 -- For usage, see Readme.markdown.
 
-{-# LANGUAGE CPP               #-}
-{-# LANGUAGE DeriveFoldable    #-}
-{-# LANGUAGE DeriveFunctor     #-}
-{-# LANGUAGE DeriveTraversable #-}
-{-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP                #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveFoldable     #-}
+{-# LANGUAGE DeriveFunctor      #-}
+{-# LANGUAGE DeriveTraversable  #-}
+{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE OverloadedStrings  #-}
 
 module Database.PostgreSQL.Simple.Migration
     (
@@ -29,6 +30,7 @@ module Database.PostgreSQL.Simple.Migration
     , MigrationContext(..)
     , MigrationCommand(..)
     , MigrationResult(..)
+    , MigrationException(..)
     , ScriptName
     , Checksum
 
@@ -42,6 +44,8 @@ module Database.PostgreSQL.Simple.Migration
 #if __GLASGOW_HASKELL__ < 710
 import           Control.Applicative                ((<$>), (<*>))
 #endif
+import           Control.Exception                  (Exception, catch,
+                                                     fromException, throw)
 import           Control.Monad                      (void, when)
 import qualified Crypto.Hash.MD5                    as MD5 (hash)
 import qualified Data.ByteString                    as BS (ByteString, readFile)
@@ -53,9 +57,10 @@ import           Data.Traversable                   (Traversable)
 import           Data.Monoid                        (Monoid (..))
 #endif
 import           Data.Time                          (LocalTime)
+import           Data.Typeable                      (Typeable)
 import           Database.PostgreSQL.Simple         (Connection, Only (..),
-                                                     execute, execute_, query,
-                                                     query_)
+                                                     SqlError, execute,
+                                                     execute_, query, query_)
 import           Database.PostgreSQL.Simple.FromRow (FromRow (..), field)
 import           Database.PostgreSQL.Simple.ToField (ToField (..))
 import           Database.PostgreSQL.Simple.ToRow   (ToRow (..))
@@ -321,3 +326,7 @@ instance FromRow SchemaMigration where
 instance ToRow SchemaMigration where
     toRow (SchemaMigration name checksum executedAt) =
        [toField name, toField checksum, toField executedAt]
+
+data MigrationException = MigrationException Query SqlError deriving (Show, Typeable)
+
+instance Exception MigrationException

--- a/src/Database/PostgreSQL/Simple/Migration.hs
+++ b/src/Database/PostgreSQL/Simple/Migration.hs
@@ -138,9 +138,9 @@ executeMigration con verbose name contents = do
             when verbose $ putStrLn $ "Ok:\t" ++ name
             return MigrationSuccess
         ScriptNotExecuted -> do
+            when verbose $ putStrLn $ "Execute:\t" ++ name
             void $ execute_ con (Query contents)
             void $ execute con q (name, checksum)
-            when verbose $ putStrLn $ "Execute:\t" ++ name
             return MigrationSuccess
         ScriptModified _ -> do
             when verbose $ putStrLn $ "Fail:\t" ++ name

--- a/src/Database/PostgreSQL/Simple/Parser.hs
+++ b/src/Database/PostgreSQL/Simple/Parser.hs
@@ -1,0 +1,73 @@
+-- |
+-- Module      : Database.PostgreSQL.Simple.Util
+-- Copyright   : (c) 2014 Andreas Meingast <ameingast@gmail.com>
+--
+-- License     : BSD-style
+-- Maintainer  : ameingast@gmail.com
+-- Stability   : experimental
+-- Portability : GHC
+--
+-- A collection of utilites for database migrations.
+
+{-# LANGUAGE RecordWildCards #-}
+
+module Database.PostgreSQL.Simple.Parser
+  (
+    toQueries
+  ) where
+
+import qualified Data.ByteString                  as BS (ByteString, foldl)
+import qualified Data.ByteString.Builder          as BSB
+import qualified Data.ByteString.Lazy             as BSI (ByteString, toStrict)
+import           Data.Monoid                      (mempty, (<>))
+import           Data.Word
+import           Database.PostgreSQL.Simple.Types (Query (..))
+
+backslash, singleQuote, semicolon, lineFeed, carriageReturn :: Word8
+backslash = 0x5c
+singleQuote = 0x27
+semicolon = 0x3b
+lineFeed = 0x0a
+carriageReturn = 0x0d
+
+data ParsingContext = InQuote
+                    | Escaping
+                    | OutQuote
+
+data ParsedQueries =
+  Parsed { current  :: BSB.Builder
+         , previous :: [BSI.ByteString] }
+
+addToCurrent :: Word8 -> ParsedQueries -> ParsedQueries
+addToCurrent c p@Parsed{..} = p { current = current <> BSB.word8 c }
+
+finishCurrent :: ParsedQueries -> ParsedQueries
+finishCurrent p@Parsed{..} =
+  let builded = BSB.toLazyByteString current
+  in if builded == mempty
+     then p
+     else p { current = mempty
+            , previous = BSB.toLazyByteString current:previous }
+
+type ParsingState = (ParsingContext, ParsedQueries)
+
+-- | Cut a migration file into a series of queries so they can be isolated and
+-- handled sequentially, helping identify which one failed if any.
+toQueries :: BS.ByteString -> [Query]
+toQueries =
+  let parsed = BS.foldl parseChar (OutQuote, Parsed mempty [])
+      queries = reverse . previous . finishCurrent . snd . parsed
+  in fmap (Query . BSI.toStrict) . queries
+
+parseChar :: ParsingState -> Word8 -> ParsingState
+parseChar (InQuote, p) c
+  | c == backslash = (Escaping, addToCurrent c p)
+  | c == singleQuote = (OutQuote, addToCurrent c p)
+  | otherwise = (InQuote, addToCurrent c p)
+parseChar (Escaping, p) c = (InQuote, addToCurrent c p)
+parseChar (OutQuote, p) c
+  | c == singleQuote = (InQuote, addToCurrent c p)
+  | c == semicolon = (OutQuote, finishCurrent . addToCurrent semicolon $ p)
+  | c == semicolon = (OutQuote, finishCurrent . addToCurrent semicolon $ p)
+  | c `elem` [lineFeed, carriageReturn] = (OutQuote, p)
+  | otherwise = (OutQuote, addToCurrent c p)

--- a/test/Database/PostgreSQL/Simple/ParserTest.hs
+++ b/test/Database/PostgreSQL/Simple/ParserTest.hs
@@ -1,0 +1,55 @@
+-- |
+-- Module      : Database.PostgreSQL.Simple.MigrationTest
+-- Copyright   : (c) 2014 Andreas Meingast <ameingast@gmail.com>
+--
+-- License     : BSD-style
+-- Maintainer  : ameingast@gmail.com
+-- Stability   : experimental
+-- Portability : GHC
+--
+-- A collection of postgresql-simple-migration specifications.
+
+{-# LANGUAGE QuasiQuotes #-}
+
+module Database.PostgreSQL.Simple.ParserTest where
+
+import           Control.Applicative               ((<$>))
+import           Data.ByteString                   (ByteString)
+import           Data.Monoid                       (mconcat)
+import           Data.String.QQ
+import           Database.PostgreSQL.Simple.Parser (toQueries)
+import           Database.PostgreSQL.Simple.Types  (Query (..))
+import           Test.Hspec                        (Spec, describe, it,
+                                                    shouldBe)
+
+query1, query2, query3, complexQ1, complexQ2, finalQuery :: ByteString
+query1 = [s|CREATE TABLE test (test_item TEXT);|]
+query2 = [s|INSERT INTO test values ('testing');|]
+query3 = [s|DROP TABLE test;|]
+complexQ1 = [s|INSERT INTO TABLE test values
+                 ('Some;Semicolons;inside;quotes;');|]
+complexQ2 = [s|INSERT INTO TABLE test values
+                 ('Semicolons;\'inside\';a;complex;quote');|]
+finalQuery = [s|SELECT 2 + 2 AS basic|]
+
+
+parserSpec :: Spec
+parserSpec = describe "Parser" $ do
+  it "Will separate queries based on semicolon" $
+    let q = toQueries (mconcat [query1, query2, query3])
+    in length q `shouldBe` 3
+
+  it "Will parse complete queries in the right order" $
+    let q = toQueries (mconcat [query1, query2, query3])
+    in q `shouldBe` (Query <$> [query1, query2, query3])
+
+  it "Will not separate queries on semicolons inside quotes" $
+    let q = toQueries (mconcat [query1, complexQ1, query2])
+    in length q `shouldBe` 3
+
+  it "Will understand denormalized quotes" $
+    let q = toQueries (mconcat [query1, complexQ2, query2])
+    in length q `shouldBe` 3
+  it "Will be able to process a final query without a semicolon" $
+    let q = toQueries (mconcat [query1, query2, finalQuery])
+    in q `shouldBe` (Query <$> [query1, query2, finalQuery])

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -19,10 +19,12 @@ module Main
 
 import           Database.PostgreSQL.Simple               (connectPostgreSQL)
 import           Database.PostgreSQL.Simple.MigrationTest (migrationSpec)
+import           Database.PostgreSQL.Simple.ParserTest    (parserSpec)
 import           Database.PostgreSQL.Simple.Util          (withTransactionRolledBack)
 import           Test.Hspec                               (hspec)
 
 main :: IO ()
 main = do
+    hspec parserSpec
     con <- connectPostgreSQL "dbname=test"
     withTransactionRolledBack con (hspec (migrationSpec con))


### PR DESCRIPTION
This PR tries to improve error management, by helping users locate where their migration script went wrong.

- It displays the migration file handled by postgresql-simple-migration _before_ executing it. Previous behaviour was to display it only after the script had been run - so when an error arose, the name of the migration script currently run was not displayed, making it more difficult to understand what file was failing.

- It display what query was running when failing. That needed some changes : first I had to plug a specific exception type to store the query. But then I realized that script are currently considered as one, single, big query (even when there are actually several queries inside). So I had to write a small parser to separate queries, handling specific cases like escaped quotes. I looked for existing SQL parsers, but there are few in haskell, most are experimentla, and would add heavy dependencies. My solution is less elegant than a attoparsec (or any similar parsing library) based one, but - I hope - less heavyweighted. I also added tests on the parser.