### PR TITLE
add create command to generate timestamp-based migration scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 dist/
 .cabal-sandbox
 cabal.sandbox.config
+.stack-work

--- a/src/Database/PostgreSQL/Simple/Migration.hs
+++ b/src/Database/PostgreSQL/Simple/Migration.hs
@@ -262,6 +262,10 @@ instance Semigroup MigrationCommand where
 
 instance Monoid MigrationCommand where
     mempty = MigrationCommands []
+    mappend (MigrationCommands xs) (MigrationCommands ys) = MigrationCommands (xs ++ ys)
+    mappend (MigrationCommands xs) y = MigrationCommands (xs ++ [y])
+    mappend x (MigrationCommands ys) = MigrationCommands (x : ys)
+    mappend x y = MigrationCommands [x, y]
 
 -- | A sum-type denoting the result of a single migration.
 data CheckScriptResult

--- a/src/Database/PostgreSQL/Simple/Migration.hs
+++ b/src/Database/PostgreSQL/Simple/Migration.hs
@@ -255,12 +255,14 @@ data MigrationCommand
     -- ^ Performs a series of 'MigrationCommand's in sequence.
     deriving (Show, Eq, Read, Ord)
 
+instance Semigroup MigrationCommand where
+    (<>) (MigrationCommands xs) (MigrationCommands ys) = MigrationCommands (xs ++ ys)
+    (<>) (MigrationCommands xs) y = MigrationCommands (xs ++ [y])
+    (<>) x (MigrationCommands ys) = MigrationCommands (x : ys)
+    (<>) x y = MigrationCommands [x, y]
+
 instance Monoid MigrationCommand where
     mempty = MigrationCommands []
-    mappend (MigrationCommands xs) (MigrationCommands ys) = MigrationCommands (xs ++ ys)
-    mappend (MigrationCommands xs) y = MigrationCommands (xs ++ [y])
-    mappend x (MigrationCommands ys) = MigrationCommands (x : ys)
-    mappend x y = MigrationCommands [x, y]
 
 -- | A sum-type denoting the result of a single migration.
 data CheckScriptResult

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,3 @@
+resolver: lts-12.8
+packages:
+- .


### PR DESCRIPTION
Hi, this PR adds a convenient command to generate timestamp-prefixed migration script.

I've been using this for a couple of weeks, and in practice keeping the migration script name in order is a little bit inconvenient. We were increasing the prefix, for example `1.sql`, `2.sql` .etc, however there is a case when two team members create change and the increment conflict.  Django and Rails prefix their migration script name with timestamp, which I think is quite reasonable.




