### PR TITLE
Support a user defined name for the schema_migrations table

### DIFF
--- a/postgresql-simple-migration.cabal
+++ b/postgresql-simple-migration.cabal
@@ -38,7 +38,7 @@ Library
     default-extensions:     OverloadedStrings, CPP, LambdaCase
     default-language:       Haskell2010
     build-depends:          base                        >= 4.6      && < 5.0,
-                            base64-bytestring           >= 1.0      && < 1.1,
+                            base64-bytestring           >= 1.0      && < 1.2,
                             bytestring                  >= 0.10     && < 0.11,
                             cryptohash                  >= 0.11     && < 0.12,
                             directory                   >= 1.2      && < 1.4,
@@ -52,7 +52,7 @@ Executable migrate
     default-extensions:     OverloadedStrings, CPP, LambdaCase
     default-language:       Haskell2010
     build-depends:          base                        >= 4.6      && < 5.0,
-                            base64-bytestring           >= 1.0      && < 1.1,
+                            base64-bytestring           >= 1.0      && < 1.2,
                             bytestring                  >= 0.10     && < 0.11,
                             cryptohash                  >= 0.11     && < 0.12,
                             directory                   >= 1.2      && < 1.4,

--- a/postgresql-simple-migration.cabal
+++ b/postgresql-simple-migration.cabal
@@ -57,7 +57,7 @@ Executable migrate
                             cryptohash                  >= 0.11     && < 0.12,
                             directory                   >= 1.2      && < 1.4,
                             postgresql-simple           >= 0.4      && < 0.7,
-                            time                        >= 1.4      && < 1.9,
+                            time                        >= 1.4      && < 1.10,
                             text                        >= 1.2      && < 1.3
 
 test-suite tests

--- a/postgresql-simple-migration.cabal
+++ b/postgresql-simple-migration.cabal
@@ -57,7 +57,7 @@ Executable migrate
                             cryptohash                  >= 0.11     && < 0.12,
                             directory                   >= 1.2      && < 1.4,
                             postgresql-simple           >= 0.4      && < 0.7,
-                            time                        >= 1.4      && < 1.10,
+                            time                        >= 1.4      && < 1.9,
                             text                        >= 1.2      && < 1.3
 
 test-suite tests

--- a/src/Database/PostgreSQL/Simple/Migration.hs
+++ b/src/Database/PostgreSQL/Simple/Migration.hs
@@ -177,7 +177,7 @@ executeMigration con tableName verbose name contents = do
               ++ "\n" ++ scriptModifiedErrorMessage expected actual
             return (MigrationError name)
     where
-        q = "insert into " <> Query tableName <> "(filename, checksum) values(?, ?)"
+        q = "insert into " `mappend` Query tableName `mappend` "(filename, checksum) values(?, ?)"
 
 -- | Initializes the database schema with a helper table containing
 -- meta-information about executed migrations.
@@ -185,7 +185,7 @@ initializeSchema :: Connection -> BS.ByteString -> Bool -> IO ()
 initializeSchema con tableName verbose = do
     when verbose $ putStrLn "Initializing schema"
     void $ execute_ con $ mconcat
-        [ "create table if not exists " <> Query tableName <> " "
+        [ "create table if not exists " `mappend` Query tableName `mappend` " "
         , "( filename varchar(512) not null"
         , ", checksum varchar(32) not null"
         , ", executed_at timestamp without time zone not null default now() "
@@ -210,7 +210,7 @@ executeValidation con tableName' verbose cmd =
     MigrationInitialization ->
         existsTable con tableName >>= \r -> return $ if r
             then MigrationSuccess
-            else MigrationError $ "No such table: " <> tableName
+            else MigrationError $ "No such table: " `mappend` tableName
     MigrationDirectory path ->
         scriptsInDirectory path >>= goScripts path
     MigrationScript name contents ->
@@ -258,7 +258,7 @@ checkScript con tableName name fileChecksum =
                     })
     where
         q = mconcat
-            [ "select checksum from " <> Query tableName <> " "
+            [ "select checksum from " `mappend` Query tableName `mappend` " "
             , "where filename = ? limit 1"
             ]
 
@@ -360,7 +360,7 @@ getMigrations' :: Connection -> BS.ByteString -> IO [SchemaMigration]
 getMigrations' con tableName = query_ con q
     where q = mconcat
             [ "select filename, checksum, executed_at "
-            , "from " <> Query tableName <> " order by executed_at asc"
+            , "from " `mappend` Query tableName `mappend` " order by executed_at asc"
             ]
 
 -- | A product type representing a single, executed 'SchemaMigration'.

--- a/src/Database/PostgreSQL/Simple/Migration.hs
+++ b/src/Database/PostgreSQL/Simple/Migration.hs
@@ -38,6 +38,7 @@ module Database.PostgreSQL.Simple.Migration
 
     -- * Migration result actions
     , getMigrations
+    , getMigrations'
 
     -- * Migration result types
     , SchemaMigration(..)
@@ -349,10 +350,14 @@ data MigrationContext' = MigrationContext'
     , migrationTableName :: !BS.ByteString
     -- ^ The name of the table that stores the migrations
     }
+--
+-- | Produces a list of all executed 'SchemaMigration's.
+getMigrations :: Connection -> IO [SchemaMigration]
+getMigrations con = getMigrations' con "schema_migrations"
 
 -- | Produces a list of all executed 'SchemaMigration's.
-getMigrations :: Connection -> BS.ByteString -> IO [SchemaMigration]
-getMigrations con tableName = query_ con q
+getMigrations' :: Connection -> BS.ByteString -> IO [SchemaMigration]
+getMigrations' con tableName = query_ con q
     where q = mconcat
             [ "select filename, checksum, executed_at "
             , "from " <> Query tableName <> " order by executed_at asc"


### PR DESCRIPTION
Added runMigration' and runMigrations'. These two function support an extra parameter over the non-prime ones. This param is the name of the scschema_migrations table that the user has selected.

Adding two new functions like this means there are no breaking changes for existing users.