### PR TITLE
Implement log redirection interface

### DIFF
--- a/postgresql-simple-migration.cabal
+++ b/postgresql-simple-migration.cabal
@@ -43,11 +43,14 @@ Library
                             cryptohash                  >= 0.11     && < 0.12,
                             directory                   >= 1.2      && < 1.4,
                             postgresql-simple           >= 0.4      && < 0.7,
-                            time                        >= 1.4      && < 1.10
+                            time                        >= 1.4      && < 1.10,
+                            text                        >= 1.2      && < 1.3
 
 Executable migrate
     main-is:                Main.hs
     hs-source-dirs:         src
+    other-modules:          Database.PostgreSQL.Simple.Migration
+                            Database.PostgreSQL.Simple.Util
     ghc-options:            -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns
     default-extensions:     OverloadedStrings, CPP, LambdaCase
     default-language:       Haskell2010

--- a/src/Database/PostgreSQL/Simple/Util.hs
+++ b/src/Database/PostgreSQL/Simple/Util.hs
@@ -10,7 +10,6 @@
 -- A collection of utilites for database migrations.
 
 {-# LANGUAGE CPP               #-}
-{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Database.PostgreSQL.Simple.Util

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -31,6 +31,8 @@ import           Database.PostgreSQL.Simple.Migration (MigrationCommand (..),
                                                        runMigration)
 import           System.Environment                   (getArgs)
 import           System.Exit                          (exitFailure, exitSuccess)
+import           System.IO                            (Handle, hPutStrLn,
+                                                       stdout, stderr)
 
 import qualified Data.Text                            as T
 import qualified Data.Text.Encoding                   as T
@@ -38,7 +40,7 @@ import qualified Data.Text.Encoding                   as T
 main :: IO ()
 main = getArgs >>= \case
     "-h":_ ->
-        printUsage
+        printUsage stdout
     "-q":xs ->
         ppException $ run (parseCommand xs) False
     xs ->
@@ -51,7 +53,7 @@ ppException a = catch a ehandler
     ehandler e = maybe (throw e) (*> exitFailure)
                  (pSqlError <$> fromException e)
     bsToString = T.unpack . T.decodeUtf8
-    pSqlError e = mapM_ putStrLn
+    pSqlError e = mapM_ (hPutStrLn stderr)
                   [ "SqlError:"
                   , "  sqlState: "
                   , bsToString $ sqlState e
@@ -65,8 +67,8 @@ ppException a = catch a ehandler
                   , bsToString $ sqlErrorHint e
                   ]
 
-run :: Maybe Command -> Bool-> IO ()
-run Nothing  _ = printUsage >> exitFailure
+run :: Maybe Command -> Bool -> IO ()
+run Nothing _ = printUsage stderr >> exitFailure
 run (Just cmd) verbose =
     handleResult =<< case cmd of
         Initialize url -> do
@@ -91,29 +93,31 @@ parseCommand ("migrate":url:dir:_)  = Just (Migrate url dir)
 parseCommand ("validate":url:dir:_) = Just (Validate url dir)
 parseCommand _                      = Nothing
 
-printUsage :: IO ()
-printUsage = do
-    putStrLn "migrate [options] <command>"
-    putStrLn "  Options:"
-    putStrLn "      -h          Print help text"
-    putStrLn "      -q          Enable quiet mode"
-    putStrLn "  Commands:"
-    putStrLn "      init <con>"
-    putStrLn "                  Initialize the database. Required to be run"
-    putStrLn "                  at least once."
-    putStrLn "      migrate <con> <directory>"
-    putStrLn "                  Execute all SQL scripts in the provided"
-    putStrLn "                  directory in alphabetical order."
-    putStrLn "                  Scripts that have already been executed are"
-    putStrLn "                  ignored. If a script was changed since the"
-    putStrLn "                  time of its last execution, an error is"
-    putStrLn "                  raised."
-    putStrLn "      validate <con> <directory>"
-    putStrLn "                  Validate all SQL scripts in the provided"
-    putStrLn "                  directory."
-    putStrLn "      The <con> parameter is based on libpq connection string"
-    putStrLn "      syntax. Detailled information is available here:"
-    putStrLn "      <http://www.postgresql.org/docs/9.3/static/libpq-connect.html>"
+printUsage :: Handle -> IO ()
+printUsage h = do
+    say "migrate [options] <command>"
+    say "  Options:"
+    say "      -h          Print help text"
+    say "      -q          Enable quiet mode"
+    say "  Commands:"
+    say "      init <con>"
+    say "                  Initialize the database. Required to be run"
+    say "                  at least once."
+    say "      migrate <con> <directory>"
+    say "                  Execute all SQL scripts in the provided"
+    say "                  directory in alphabetical order."
+    say "                  Scripts that have already been executed are"
+    say "                  ignored. If a script was changed since the"
+    say "                  time of its last execution, an error is"
+    say "                  raised."
+    say "      validate <con> <directory>"
+    say "                  Validate all SQL scripts in the provided"
+    say "                  directory."
+    say "      The <con> parameter is based on libpq connection string"
+    say "      syntax. Detailled information is available here:"
+    say "      <http://www.postgresql.org/docs/9.3/static/libpq-connect.html>"
+    where
+        say = hPutStrLn h
 
 data Command
     = Initialize String

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -10,7 +10,6 @@
 -- The test entry-point for postgresql-simple-migration.
 
 {-# LANGUAGE CPP               #-}
-{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Main


### PR DESCRIPTION
Relates to #34 (satisfies second part).

1. Adds alternative `runMigrationA` and `runMigrationsA` functions with additional argument of type `Either Text Text -> IO ()` where `Left` is an error message and `Right` is an info message
2. By default sends error messages to `stderr` instead of `stdout`
3. Usage info in `migrate` executable is printed to `stderr` instead of `stdout` in case arguments are incorrect and executable exits with error exit code

This is the second attempt to implement the feature after #35 