### PR TITLE
relax base64-bytestring upper bound

### DIFF
--- a/postgresql-simple-migration.cabal
+++ b/postgresql-simple-migration.cabal
@@ -38,7 +38,7 @@ Library
     default-extensions:     OverloadedStrings, CPP, LambdaCase
     default-language:       Haskell2010
     build-depends:          base                        >= 4.6      && < 5.0,
-                            base64-bytestring           >= 1.0      && < 1.1,
+                            base64-bytestring           >= 1.0      && < 1.3,
                             bytestring                  >= 0.10     && < 0.11,
                             cryptohash                  >= 0.11     && < 0.12,
                             directory                   >= 1.2      && < 1.4,
@@ -52,7 +52,7 @@ Executable migrate
     default-extensions:     OverloadedStrings, CPP, LambdaCase
     default-language:       Haskell2010
     build-depends:          base                        >= 4.6      && < 5.0,
-                            base64-bytestring           >= 1.0      && < 1.1,
+                            base64-bytestring           >= 1.0      && < 1.3,
                             bytestring                  >= 0.10     && < 0.11,
                             cryptohash                  >= 0.11     && < 0.12,
                             directory                   >= 1.2      && < 1.4,


### PR DESCRIPTION
This project is correctly building using base64-bytestring-1.1.0.0.
Relaxing the upper bound accordingly.


```
$ ghc-pkg list base64-bytestring
/nix/store/wjwacdwx99hmvqzbg9f3zn970iq42gxn-ghc-8.10.4-with-packages/lib/ghc-8.10.4/package.conf.d
    base64-bytestring-1.1.0.0

$ cabal build
Resolving dependencies...
Build profile: -w ghc-8.10.4 -O1
In order, the following will be built (use -v for more details):
 - postgresql-simple-migration-0.1.15.0 (lib) (configuration changed)
 - postgresql-simple-migration-0.1.15.0 (exe:migrate) (configuration changed)
Configuring library for postgresql-simple-migration-0.1.15.0..
Configuring executable 'migrate' for postgresql-simple-migration-0.1.15.0..
Preprocessing library for postgresql-simple-migration-0.1.15.0..
Preprocessing executable 'migrate' for postgresql-simple-migration-0.1.15.0..
Building library for postgresql-simple-migration-0.1.15.0..
Building executable 'migrate' for postgresql-simple-migration-0.1.15.0..

<no location info>: warning: [-Wmissing-home-modules]
    These modules are needed for compilation but not listed in your .cabal file's other-modules: 
        Database.PostgreSQL.Simple.Migration
        Database.PostgreSQL.Simple.Util

<no location info>: warning: [-Wmissing-home-modules]
    These modules are needed for compilation but not listed in your .cabal file's other-modules: 
        Database.PostgreSQL.Simple.Migration
```

